### PR TITLE
Because of the default title, containing slashes, the generated html …

### DIFF
--- a/modules/registrars/realtimeregister/src/Widget/BalanceModuleWidget.php
+++ b/modules/registrars/realtimeregister/src/Widget/BalanceModuleWidget.php
@@ -4,7 +4,7 @@ namespace RealtimeRegisterDomains\Widget;
 
 use RealtimeRegisterDomains\App;
 
-class BalanceModuleWidget extends \WHMCS\Module\AbstractWidget
+class BalanceModuleWidget extends BaseWidget
 {
     protected $title = 'Realtime Register - Balance';
     protected $description = '';

--- a/modules/registrars/realtimeregister/src/Widget/BaseWidget.php
+++ b/modules/registrars/realtimeregister/src/Widget/BaseWidget.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace RealtimeRegisterDomains\Widget;
+
+abstract class BaseWidget extends \WHMCS\Module\AbstractWidget
+{
+    public function getId()
+    {
+        return 'realtimeregister-' . $this->getClassname();
+    }
+
+    private function getClassname(): string
+    {
+        $classname = get_called_class();
+        if ($pos = strrpos($classname, '\\')) {
+            return substr($classname, $pos + 1);
+        }
+
+        return $pos;
+    }
+}

--- a/modules/registrars/realtimeregister/src/Widget/DomainOverviewModuleWidget.php
+++ b/modules/registrars/realtimeregister/src/Widget/DomainOverviewModuleWidget.php
@@ -4,7 +4,7 @@ namespace RealtimeRegisterDomains\Widget;
 
 use RealtimeRegisterDomains\App;
 
-class DomainOverviewModuleWidget extends \WHMCS\Module\AbstractWidget
+class DomainOverviewModuleWidget extends BaseWidget
 {
     protected $title = 'Realtime Register - Domain statistics';
     protected $description = '';

--- a/modules/registrars/realtimeregister/src/Widget/ErrorLogWidget.php
+++ b/modules/registrars/realtimeregister/src/Widget/ErrorLogWidget.php
@@ -4,7 +4,7 @@ namespace RealtimeRegisterDomains\Widget;
 
 use RealtimeRegisterDomains\Services\TemplateService;
 
-class ErrorLogWidget extends \WHMCS\Module\AbstractWidget
+class ErrorLogWidget extends BaseWidget
 {
     protected $title = 'Realtime Register - Error Log';
     protected $description = '';

--- a/modules/registrars/realtimeregister/src/Widget/PromoWidget.php
+++ b/modules/registrars/realtimeregister/src/Widget/PromoWidget.php
@@ -6,7 +6,7 @@ use RealtimeRegisterDomains\Actions\Tlds\GetPricesTrait;
 use RealtimeRegisterDomains\App;
 use RealtimeRegisterDomains\Services\TemplateService;
 
-class PromoWidget extends \WHMCS\Module\AbstractWidget
+class PromoWidget extends BaseWidget
 {
     use GetPricesTrait;
 

--- a/modules/registrars/realtimeregister/src/Widget/UpdateWidget.php
+++ b/modules/registrars/realtimeregister/src/Widget/UpdateWidget.php
@@ -4,7 +4,7 @@ namespace RealtimeRegisterDomains\Widget;
 
 use RealtimeRegisterDomains\Services\TemplateService;
 
-class UpdateWidget extends \WHMCS\Module\AbstractWidget
+class UpdateWidget extends BaseWidget
 {
     protected $title = 'Realtimeregister updates';
     protected $wrapper = false;


### PR DESCRIPTION
…id was not correct, and we weren't able to hide the widgets