### PR TITLE
Enhance getBasePath for asset URL resolution

### DIFF
--- a/modules/registrars/realtimeregister/src/Services/Assets.php
+++ b/modules/registrars/realtimeregister/src/Services/Assets.php
@@ -5,6 +5,8 @@ namespace RealtimeRegisterDomains\Services;
 use RealtimeRegisterDomains\App;
 use RealtimeRegisterDomains\Enums\ScriptLocationType;
 
+use WHMCS\Config\Setting;
+
 final class Assets
 {
     protected static array $head = [];
@@ -135,14 +137,23 @@ final class Assets
         return $content;
     }
 
-    private function getBasePath(string $assetUrl): string
-    {
-        $basePath = realpath(__DIR__ . '/../../../../../');
-        $baseModulePath = realpath(__DIR__ . '/../');
-        $basePath = str_replace($basePath, '', $baseModulePath);
+ private function getBasePath(string $assetUrl): string
+{
+    // Filesystem: WHMCS root and this module's /src folder
+    $fsWhmcsRoot  = realpath(__DIR__ . '/../../../../../');
+    $fsModuleSrc  = realpath(__DIR__ . '/../');
 
-        return $basePath . $assetUrl;
-    }
+    // Relative web path to the module's /src (e.g. /modules/registrars/realtimeregister/src)
+    $relative = str_replace($fsWhmcsRoot, '', $fsModuleSrc);
+    $relative = str_replace(DIRECTORY_SEPARATOR, '/', $relative);
+
+    // Prepend the SystemURL *path* (handles installs under /clients, /billing, etc.)
+    $systemPath = parse_url(Setting::getValue('SystemURL'), PHP_URL_PATH) ?? '';
+    $systemPath = rtrim($systemPath, '/');
+
+    // Final absolute path for href/src (no scheme/host so getPath() won’t break https://)
+    return $systemPath . $relative . $assetUrl;
+}
 
     public function addStyle(string $name): self
     {


### PR DESCRIPTION
RealtimeRegisterDomains\Services\Assets::getBasePath() builds web paths from filesystem paths but doesn’t prefix the SystemURL path. So links start at /modules/... instead of /WHMCSFOLDER/modules/.... We refactor getBasePath method to include system path handling.