### PR TITLE
Widgets are always loaded..

### DIFF
--- a/modules/registrars/realtimeregister/src/App.php
+++ b/modules/registrars/realtimeregister/src/App.php
@@ -20,7 +20,7 @@ use RuntimeException;
 class App
 {
     public const NAME = 'realtimeregister';
-    public const VERSION = '2.8.0';
+    public const VERSION = '2.9.0';
     private const CACHE_KEY_VERSION = 'realtimeregister_domains_version_number';
 
     protected const API_URL = "https://api.yoursrs.com/";

--- a/modules/registrars/realtimeregister/src/Hooks/Widgets/ActionsWidget.php
+++ b/modules/registrars/realtimeregister/src/Hooks/Widgets/ActionsWidget.php
@@ -7,8 +7,8 @@ use RealtimeRegisterDomains\Hooks\Hook;
 
 class ActionsWidget extends Hook
 {
-    public function __invoke(DataObject $vars)
+    public function __invoke(DataObject $vars): \RealtimeRegisterDomains\Widget\ActionsWidget
     {
-        return new \RealtimeRegisterDomains\Widget\ActionsWidget();
+        return new \RealtimeRegisterDomains\Widget\ActionsWidget($vars);
     }
 }

--- a/modules/registrars/realtimeregister/src/Hooks/Widgets/BalanceWidget.php
+++ b/modules/registrars/realtimeregister/src/Hooks/Widgets/BalanceWidget.php
@@ -7,8 +7,8 @@ use RealtimeRegisterDomains\Hooks\Hook;
 
 class BalanceWidget extends Hook
 {
-    public function __invoke(DataObject $vars)
+    public function __invoke(DataObject $vars): \RealtimeRegisterDomains\Widget\BalanceModuleWidget
     {
-        return new \RealtimeRegisterDomains\Widget\BalanceModuleWidget();
+        return new \RealtimeRegisterDomains\Widget\BalanceModuleWidget($vars);
     }
 }

--- a/modules/registrars/realtimeregister/src/Hooks/Widgets/DomainOverviewWidget.php
+++ b/modules/registrars/realtimeregister/src/Hooks/Widgets/DomainOverviewWidget.php
@@ -7,8 +7,8 @@ use RealtimeRegisterDomains\Hooks\Hook;
 
 class DomainOverviewWidget extends Hook
 {
-    public function __invoke(DataObject $vars)
+    public function __invoke(DataObject $vars): \RealtimeRegisterDomains\Widget\DomainOverviewModuleWidget
     {
-        return new \RealtimeRegisterDomains\Widget\DomainOverviewModuleWidget();
+        return new \RealtimeRegisterDomains\Widget\DomainOverviewModuleWidget($vars);
     }
 }

--- a/modules/registrars/realtimeregister/src/Hooks/Widgets/ErrorLogWidget.php
+++ b/modules/registrars/realtimeregister/src/Hooks/Widgets/ErrorLogWidget.php
@@ -7,8 +7,8 @@ use RealtimeRegisterDomains\Hooks\Hook;
 
 class ErrorLogWidget extends Hook
 {
-    public function __invoke(DataObject $vars)
+    public function __invoke(DataObject $vars): \RealtimeRegisterDomains\Widget\ErrorLogWidget
     {
-        return new \RealtimeRegisterDomains\Widget\ErrorLogWidget();
+        return new \RealtimeRegisterDomains\Widget\ErrorLogWidget($vars);
     }
 }

--- a/modules/registrars/realtimeregister/src/Hooks/Widgets/InactiveDomainWidget.php
+++ b/modules/registrars/realtimeregister/src/Hooks/Widgets/InactiveDomainWidget.php
@@ -7,8 +7,8 @@ use RealtimeRegisterDomains\Hooks\Hook;
 
 class InactiveDomainWidget extends Hook
 {
-    public function __invoke(DataObject $vars)
+    public function __invoke(DataObject $vars): \RealtimeRegisterDomains\Widget\InactiveDomainsWidget
     {
-        return new \RealtimeRegisterDomains\Widget\InactiveDomainsWidget();
+        return new \RealtimeRegisterDomains\Widget\InactiveDomainsWidget($vars);
     }
 }

--- a/modules/registrars/realtimeregister/src/Hooks/Widgets/PromoWidget.php
+++ b/modules/registrars/realtimeregister/src/Hooks/Widgets/PromoWidget.php
@@ -7,8 +7,8 @@ use RealtimeRegisterDomains\Hooks\Hook;
 
 class PromoWidget extends Hook
 {
-    public function __invoke(DataObject $vars)
+    public function __invoke(DataObject $vars): \RealtimeRegisterDomains\Widget\PromoWidget
     {
-        return new \RealtimeRegisterDomains\Widget\PromoWidget();
+        return new \RealtimeRegisterDomains\Widget\PromoWidget($vars);
     }
 }

--- a/modules/registrars/realtimeregister/src/Hooks/Widgets/UpdateWidget.php
+++ b/modules/registrars/realtimeregister/src/Hooks/Widgets/UpdateWidget.php
@@ -4,12 +4,11 @@ namespace RealtimeRegisterDomains\Hooks\Widgets;
 
 use RealtimeRegisterDomains\Entities\DataObject;
 use RealtimeRegisterDomains\Hooks\Hook;
-use WHMCS\Module\AbstractWidget;
 
 class UpdateWidget extends Hook
 {
     public function __invoke(DataObject $vars): \RealtimeRegisterDomains\Widget\UpdateWidget
     {
-        return new \RealtimeRegisterDomains\Widget\UpdateWidget();
+        return new \RealtimeRegisterDomains\Widget\UpdateWidget($vars);
     }
 }

--- a/modules/registrars/realtimeregister/src/Widget/ActionsWidget.php
+++ b/modules/registrars/realtimeregister/src/Widget/ActionsWidget.php
@@ -10,7 +10,7 @@ class ActionsWidget extends BalanceModuleWidget
     protected $description = '';
     protected $weight = 150;
     protected $columns = 1;
-    protected $cache = false;
+    protected $cache = true;
     protected $cacheExpiry = 120;
     protected $requiredPermission = '';
 

--- a/modules/registrars/realtimeregister/src/Widget/BalanceModuleWidget.php
+++ b/modules/registrars/realtimeregister/src/Widget/BalanceModuleWidget.php
@@ -10,18 +10,20 @@ class BalanceModuleWidget extends BaseWidget
     protected $description = '';
     protected $weight = 150;
     protected $columns = 1;
-    protected $cache = false;
+    protected $cache = true;
     protected $cacheExpiry = 120;
     protected $requiredPermission = '';
 
     public function getData()
     {
-        try {
-            $credits = App::client()->customers->credits(App::registrarConfig()->customerHandle());
-            return $credits->entities;
-        } catch (\Exception) {
-            return 0;
+        if ($this->isVisible()) {
+            try {
+                $credits = App::client()->customers->credits(App::registrarConfig()->customerHandle());
+                return $credits->entities;
+            } catch (\Exception) {
+            }
         }
+        return 0;
     }
 
     public function generateOutput($data): string

--- a/modules/registrars/realtimeregister/src/Widget/BaseWidget.php
+++ b/modules/registrars/realtimeregister/src/Widget/BaseWidget.php
@@ -2,8 +2,18 @@
 
 namespace RealtimeRegisterDomains\Widget;
 
+use RealtimeRegisterDomains\Entities\DataObject;
+use RealtimeRegisterDomains\Models\Whmcs\Admin;
+
 abstract class BaseWidget extends \WHMCS\Module\AbstractWidget
 {
+    protected DataObject $vars;
+
+    public function __construct(DataObject $vars)
+    {
+        $this->vars = $vars;
+    }
+
     public function getId(): string
     {
         $classname = get_called_class();
@@ -12,5 +22,19 @@ abstract class BaseWidget extends \WHMCS\Module\AbstractWidget
         }
 
         return $pos;
+    }
+
+    protected function isVisible(): bool
+    {
+        $admin = Admin::query()->find($this->vars->get('adminid'));
+
+        $hiddenWidgets = $admin->hidden_widgets;
+
+        if ($hiddenWidgets) {
+            if (in_array($this->getId(), explode(',', $hiddenWidgets))) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/modules/registrars/realtimeregister/src/Widget/DomainOverviewModuleWidget.php
+++ b/modules/registrars/realtimeregister/src/Widget/DomainOverviewModuleWidget.php
@@ -10,18 +10,20 @@ class DomainOverviewModuleWidget extends BaseWidget
     protected $description = '';
     protected $weight = 150;
     protected $columns = 1;
-    protected $cache = false;
+    protected $cache = true;
     protected $cacheExpiry = 120;
     protected $requiredPermission = '';
 
-    public function getData()
+    public function getData(): int
     {
-        try {
-            $domainStatistics = App::client()->domains->list(limit: 1);
-        } catch (\Exception) {
-            return 0;
+        if ($this->isVisible()) {
+            try {
+                $domainStatistics = App::client()->domains->list(limit: 1);
+                return $domainStatistics->pagination->total;
+            } catch (\Exception) {
+            }
         }
-        return $domainStatistics->pagination->total;
+        return 0;
     }
 
     public function generateOutput($data): string

--- a/modules/registrars/realtimeregister/src/Widget/ErrorLogWidget.php
+++ b/modules/registrars/realtimeregister/src/Widget/ErrorLogWidget.php
@@ -10,7 +10,7 @@ class ErrorLogWidget extends BaseWidget
     protected $description = '';
     protected $weight = 150;
     protected $columns = 1;
-    protected $cache = false;
+    protected $cache = true;
 
     public function getData(): array
     {

--- a/modules/registrars/realtimeregister/src/Widget/InactiveDomainsWidget.php
+++ b/modules/registrars/realtimeregister/src/Widget/InactiveDomainsWidget.php
@@ -12,13 +12,16 @@ class InactiveDomainsWidget extends BaseWidget
     protected $description = '';
     protected $weight = 150;
     protected $columns = 1;
-    protected $cache = false;
+    protected $cache = true;
     protected $cacheExpiry = 120;
     protected $requiredPermission = '';
 
     public function getData(): array
     {
-        return InactiveDomains::all()->toArray();
+        if ($this->isVisible()) {
+            return InactiveDomains::all()->toArray();
+        }
+        return [];
     }
 
     public function generateOutput($data): string

--- a/modules/registrars/realtimeregister/src/Widget/PromoWidget.php
+++ b/modules/registrars/realtimeregister/src/Widget/PromoWidget.php
@@ -15,19 +15,20 @@ class PromoWidget extends BaseWidget
     protected $weight = 150;
     protected $columns = 1;
     protected $height = 150;
-    protected $cache = false;
+    protected $cache = true;
     protected $cacheExpiry = 60 * 60 * 24; // One day
     protected $requiredPermission = '';
 
     public function getData(): array
     {
-        try {
-            $promotions = App::client()->customers->promoList(App::registrarConfig()->customerHandle());
-        } catch (\Exception) {
-            return [];
+        if ($this->isVisible()) {
+            try {
+                $promotions = App::client()->customers->promoList(App::registrarConfig()->customerHandle());
+                return ['promotions' => $promotions];
+            } catch (\Exception) {
+            }
         }
-
-        return ['promotions' => $promotions];
+        return [];
     }
 
     public function generateOutput($data): string


### PR DESCRIPTION
When you hide a WHMCS widget, the widget will always get loaded, so it was only a visual trigger. The default WHMCS widgets follow the same pattern. I've now added an option to detect if the user(admin) is hiding the widget. If that is the case, we skip the api calls. When the widget is enabled, they will load the data.

I think this will finally solve the problem indicated in https://github.com/realtimeregister/whmcs-domains/issues/218 ..