### PR TITLE
If there is already a contact update request being worked on at 

### DIFF
--- a/modules/registrars/realtimeregister/src/Hooks/ContactEdit.php
+++ b/modules/registrars/realtimeregister/src/Hooks/ContactEdit.php
@@ -115,7 +115,7 @@ class ContactEdit extends Hook
                             $exception,
                             sprintf("Splitting contact from %s to %s", $mapping->handle, $newHandle)
                         );
-                    } else if (is_array($errorMessage) && $errorMessage['type'] == 'ObjectExists') {
+                    } elseif (is_array($errorMessage) && $errorMessage['type'] == 'ObjectExists') {
                         LogService::logError(
                             $exception,
                             sprintf("Update contact command for %s already exists", $mapping->handle)

--- a/modules/registrars/realtimeregister/src/Hooks/ContactEdit.php
+++ b/modules/registrars/realtimeregister/src/Hooks/ContactEdit.php
@@ -115,6 +115,11 @@ class ContactEdit extends Hook
                             $exception,
                             sprintf("Splitting contact from %s to %s", $mapping->handle, $newHandle)
                         );
+                    } else if (is_array($errorMessage) && $errorMessage['type'] == 'ObjectExists') {
+                        LogService::logError(
+                            $exception,
+                            sprintf("Update contact command for %s already exists", $mapping->handle)
+                        );
                     } else {
                         LogService::logError($exception, json_encode($diff));
                         throw $exception;


### PR DESCRIPTION
Realtime Register, we used to throw an error. We now silently ignore the subsequent requests because most of the time the requests are duplicated because of multiple fast submits of the contact edit page

Fixes #223